### PR TITLE
Upkeep Changes, Team Damage, Enhanced Team Colors

### DIFF
--- a/TemplarWar/src/config.yml
+++ b/TemplarWar/src/config.yml
@@ -9,6 +9,7 @@ messages:
         chunkclaimed: "&9Guilds> &7You have claimed this chunk"
         chunkunclaimed: "&9Guilds> &7You have unclaimed this chunk"
         error:
+            takingteamname: "&9Guilds> &7You cannot create a guild with the same name as a team"
             noinvite: "&9Guilds> &7You do not have an invite for that guild"
             invalidname: "&9Guilds> &7Guild names must be alphanumeric and less than 12 characters"
             hasinvite: "&9Guilds> &7You've already sent an invite to that player"
@@ -21,7 +22,7 @@ messages:
             notownchunk: "&9Guilds> &7You do not own this chunk!"
             notenoughfunds: "&9Guilds> &7You lack the funds to create a guild"
             inviteotherteam: "&9Guilds> &7You cannot invite a player from a different team"
-            joinotherteam: "&9Guilds> &7You cannot join a guild apart of a different team"
+            joinotherteam: "&9Guilds> &7You cannot join a guild of a different team"
             kickself: "&9Guilds> &7You cannot kick yourself"
             inviteself: "&9Guilds> &7You cannot invite yourself"
             inviteplayeringuild: "&9Guilds> &7You cannot invite a player who is in a guild"
@@ -32,8 +33,8 @@ messages:
             demotemember: "&9Guilds> &7You cannot demote a member"
             nohomeset: "&9Guilds> &7Your guild does not have a home set"
             alreadyteleporting: "&9Guilds> &7You are already teleporting"
-            movedduringteleport: "&9Guilds> &7Teleportation cancelled, you moved"
-            cancelteleportnotinguild: "&9Guilds> &7Teleportation cancelled, you are not in a guild"
+            movedduringteleport: "&9Guilds> &7Teleportation canceled because you moved"
+            cancelteleportnotinguild: "&9Guilds> &7Teleportation canceled because you are not in a guild"
             sethomeinclaim: "&9Guilds> &7You must set your home inside of your guild's territory"
             invalidnumberinput: "&9Guilds> &7You must enter a valid number to withdraw"
             withdrawtoomuch: "&9Guilds> &7You cannot withdraw more thank your guild's balance"
@@ -45,14 +46,17 @@ messages:
     team:
         error:
             invalidname: "&9Teams> &7That is an invalid team name"
+            nameinuse: "&9Teams> &7That name is already in use"
             inteam: "&9Teams> &7You are already in a team"
             notinteam: "&9Teams> &7You must be in a team to use this command"
             invalidteam: "&9Teams> &7That team does not exist"
             leaveinguild: "&9Teams> &7You cannot leave a team while in a guild"
             invalidcolor: "&9Teams> &7That is not a valid color"
-        colorset: "&9Teams> &7Team color sucessfully set"
+        colorset: "&9Teams> &7Team color successfully set"
 defaults:
     maxclaimcount: 10
+    upkeepcostpermember: 200
+    upkeepcostperclaim: 400
     claimcost: 500
     maxbankamount: 18000
     raidtime: 300

--- a/TemplarWar/src/me/Duppy/TemplarWar/Commands/Guilds/Commands/user/GuildCreate.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Commands/Guilds/Commands/user/GuildCreate.java
@@ -34,7 +34,9 @@ public class GuildCreate implements CMD{
 				if(TeamManager.getTeam(p.getUniqueId())!= null) {
 					if(check(args[1]) && args[1].length() <= 12) {
 						if(Main.getVault().getEconomy().getBalance(p) >= Plugin.plugin.getConfig().getDouble("defaults.guildcreateprice")) {
-							return true;
+							if(!GuildManager.isTeamName(args[1])) {
+								return true;
+							}else {MessageManager.sendMessage(p, "guild.error.takingteamname"); return false;}
 						}else {MessageManager.sendMessage(p, "guild.error.notenoughfunds"); return false;}
 					}else {MessageManager.sendMessage(p, "guild.error.invalidname"); return false;}
 				}else {MessageManager.sendMessage(p, "team.error.notinteam"); return false;}

--- a/TemplarWar/src/me/Duppy/TemplarWar/Commands/Guilds/Commands/user/GuildDeposit.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Commands/Guilds/Commands/user/GuildDeposit.java
@@ -29,7 +29,7 @@ public class GuildDeposit implements CMD{
                 sender.sendMessage(String.format(ChatColor.BLUE + "Guilds> "+
                 		ChatColor.GRAY +"You deposited"+
                 		ChatColor.YELLOW+" %s"+
-                		ChatColor.GRAY+ "and now have"+
+                		ChatColor.GRAY+ " and now have"+
                 		ChatColor.YELLOW+" %s", 
                 		Main.getVault().getEconomy().format(r.amount), 
                 		Main.getVault().getEconomy().format(r.balance)));

--- a/TemplarWar/src/me/Duppy/TemplarWar/Commands/Guilds/Commands/user/GuildInfo.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Commands/Guilds/Commands/user/GuildInfo.java
@@ -1,5 +1,7 @@
 package me.Duppy.TemplarWar.Commands.Guilds.Commands.user;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 
 import org.bukkit.Bukkit;
@@ -72,8 +74,15 @@ public class GuildInfo implements CMD {
 			
 			//Setting lore
 			goldlores.add(ChatColor.GREEN + "Balance: "+ChatColor.YELLOW + g.getBalance());
+			double hoursLeft = (g.getBalance()/(g.getUpkeep()/24));
+			double minutesLeft = (g.getBalance()/(g.getUpkeep()/1440));
+			minutesLeft = round(minutesLeft,2);
+			hoursLeft = round(hoursLeft,2);
+			if(hoursLeft > 1)
+				goldlores.add(ChatColor.GREEN + "Hours Left: "+ChatColor.YELLOW+hoursLeft);
+			else
+				goldlores.add(ChatColor.GREEN + "Minutes Left: "+ChatColor.YELLOW+minutesLeft);
 			goldlores.add(ChatColor.GREEN + "Upkeep: "+ChatColor.RED+ g.getUpkeep());
-
 			
 			//Setting lore to item
 			goldmetas.setLore(goldlores);
@@ -158,6 +167,14 @@ public class GuildInfo implements CMD {
 	public String getUsage() {
 		// TODO Auto-generated method stub
 		return null;
+	}
+	
+	private static double round(double value, int places) {
+	    if (places < 0) throw new IllegalArgumentException();
+
+	    BigDecimal bd = BigDecimal.valueOf(value);
+	    bd = bd.setScale(places, RoundingMode.HALF_UP);
+	    return bd.doubleValue();
 	}
 
 }

--- a/TemplarWar/src/me/Duppy/TemplarWar/Commands/Guilds/Commands/user/GuildWithdraw.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Commands/Guilds/Commands/user/GuildWithdraw.java
@@ -29,7 +29,7 @@ public class GuildWithdraw implements CMD {
                 sender.sendMessage(String.format(ChatColor.BLUE + "Guilds> "+
                 		ChatColor.GRAY +"You withdrew"+
                 		ChatColor.YELLOW+" %s"+
-                		ChatColor.GRAY+ "and now have"+
+                		ChatColor.GRAY+ " and now have"+
                 		ChatColor.YELLOW+" %s", 
                 		Main.getVault().getEconomy().format(r.amount), 
                 		Main.getVault().getEconomy().format(r.balance)));

--- a/TemplarWar/src/me/Duppy/TemplarWar/Commands/Teams/user/TeamsCreate.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Commands/Teams/user/TeamsCreate.java
@@ -4,6 +4,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import me.Duppy.TemplarWar.Commands.CMD;
+import me.Duppy.TemplarWar.Guilds.Guilds.GuildManager;
 import me.Duppy.TemplarWar.Guilds.Guilds.MessageManager;
 import me.Duppy.TemplarWar.Teams.Team;
 import me.Duppy.TemplarWar.Teams.TeamManager;
@@ -28,7 +29,13 @@ public class TeamsCreate implements CMD{
 			if(p.hasPermission("teams.create")) {
 				if(TeamManager.getTeam(p.getUniqueId()) == null) {
 					if(args[1].length() <= 12 && check(args[1]))
-						return true;
+						if(!GuildManager.isTeamName(args[1])) {
+							return true;
+						}
+						else {
+							MessageManager.sendMessage(p, "team.error.nameinuse");
+							return false;
+						}
 					else {
 						MessageManager.sendMessage(p, "team.error.invalidname");
 						return false;

--- a/TemplarWar/src/me/Duppy/TemplarWar/Guilds/Guilds/Guild.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Guilds/Guilds/Guild.java
@@ -1,5 +1,7 @@
 package me.Duppy.TemplarWar.Guilds.Guilds;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -106,7 +108,7 @@ public class Guild {
 	}
 	
 	public double getBalance() {
-		return balance;
+		return round(balance,2);
 	}
 	public void setBalance(double balance) {
 		if(balance > Plugin.plugin.getConfig().getDouble("defaults.maxbankamount"))
@@ -128,7 +130,8 @@ public class Guild {
 	}
 	
 	public double getUpkeep() {
-		return (guildMap.size() * 20) + (chunks.size() * 40) + 100;
+		return (guildMap.size() * Plugin.plugin.getConfig().getDouble("defaults.upkeepcostpermember")) 
+				+ (chunks.size() * Plugin.plugin.getConfig().getDouble("defaults.upkeepcostperclaim")) + 100;
 	}
 	//METHODS
 	
@@ -136,23 +139,28 @@ public class Guild {
 	public void updateColor() {
 		switch(this.team.getColor()) {
 		case "green":
-			this.scoreBoardTeam.setPrefix(ChatColor.GREEN + "" + this.name + " ");
+			this.scoreBoardTeam.setPrefix(ChatColor.GREEN + "" +ChatColor.BOLD+  this.name + " ");
+			this.scoreBoardTeam.setColor(ChatColor.GREEN);
 			break;
 			
 		case "blue":
-			this.scoreBoardTeam.setPrefix(ChatColor.BLUE + "" + this.name + " ");
+			this.scoreBoardTeam.setPrefix(ChatColor.BLUE + "" +ChatColor.BOLD+ this.name + " ");
+			this.scoreBoardTeam.setColor(ChatColor.BLUE);
 			break;
 		
 		case "red":
-			this.scoreBoardTeam.setPrefix(ChatColor.RED + "" + this.name + " ");
+			this.scoreBoardTeam.setPrefix(ChatColor.RED + "" +ChatColor.BOLD+ this.name + " ");
+			this.scoreBoardTeam.setColor(ChatColor.RED);
 			break;
 		case "yellow":
-			this.scoreBoardTeam.setPrefix(ChatColor.YELLOW + "" + this.name + " ");
+			this.scoreBoardTeam.setPrefix(ChatColor.YELLOW + "" +ChatColor.BOLD+  this.name + " ");
+			this.scoreBoardTeam.setColor(ChatColor.YELLOW);
 			break;
 			
 		//This should never call. Team color should also be set or default by red.
 		default:
-			this.scoreBoardTeam.setPrefix(ChatColor.RED + "" + this.name + " ");
+			this.scoreBoardTeam.setPrefix(ChatColor.RED + "" +ChatColor.BOLD+  this.name + " ");
+			this.scoreBoardTeam.setColor(ChatColor.RED);
 			break;
 		}
 	}
@@ -163,6 +171,7 @@ public class Guild {
 	
 	public void addMember(UUID uuid) {
 		if(!(this.guildMap.containsKey(uuid))) {
+			getTeam().getScoreBoardTeam().removeEntry(ConfigManager.getPlayers().getString(uuid.toString()));
 			this.scoreBoardTeam.addEntry(ConfigManager.getPlayers().getString(uuid.toString()));
 			guildMap.put(uuid, "MEMBER");
 		}
@@ -180,11 +189,13 @@ public class Guild {
 				case "ADMIN":
 					guildMap.remove(uuid);
 					this.scoreBoardTeam.removeEntry(ConfigManager.getPlayers().getString(uuid.toString()));
+					getTeam().getScoreBoardTeam().addEntry(ConfigManager.getPlayers().getString(uuid.toString()));
 					break;
 					
 				case "MEMBER":
 					guildMap.remove(uuid);
 					this.scoreBoardTeam.removeEntry(ConfigManager.getPlayers().getString(uuid.toString()));
+					getTeam().getScoreBoardTeam().addEntry(ConfigManager.getPlayers().getString(uuid.toString()));
 					break;
 					
 			}
@@ -256,5 +267,13 @@ public class Guild {
 	        }
 	    }
 	    return null;
+	}
+	
+	private static double round(double value, int places) {
+	    if (places < 0) throw new IllegalArgumentException();
+
+	    BigDecimal bd = BigDecimal.valueOf(value);
+	    bd = bd.setScale(places, RoundingMode.HALF_UP);
+	    return bd.doubleValue();
 	}
 }

--- a/TemplarWar/src/me/Duppy/TemplarWar/Guilds/Guilds/GuildManager.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Guilds/Guilds/GuildManager.java
@@ -157,6 +157,12 @@ public class GuildManager {
 	public static void removeGuild(Guild guild) {
 		if(guildList.contains(guild)) {
 			mainScoreboard.getTeam(guild.getName()).unregister();
+			//Add player back to general team scoreboard
+			String playername = "";
+			for(Entry<UUID, String> u : guild.getGuildMap().entrySet()) {
+				playername = ConfigManager.getPlayername(u.getKey());
+				guild.getTeam().getScoreBoardTeam().addEntry(playername);
+			}
 			guildList.remove(guild);
 		}
 		if(guild.getTeam().getGuilds().contains(guild)) {
@@ -180,14 +186,24 @@ public class GuildManager {
 		Iterator<Guild> itr = guildList.iterator();
 	    while (itr.hasNext()) {
 	      Guild g = itr.next();
-	      balanceAfter = g.getBalance()-g.getUpkeep();
+	      balanceAfter = g.getBalance()-(g.getUpkeep()/86400);
 	      if (balanceAfter <= 0) {
 	    	g.getTeam().getGuilds().remove(g);
+	    	mainScoreboard.getTeam(g.getName()).unregister();
 	        itr.remove();
+	      }
+	      else {
+	    	  g.setBalance(balanceAfter);
 	      }
 	    }
 	}
 	
-	
+	public static boolean isTeamName(String name) {
+		for(org.bukkit.scoreboard.Team t : mainScoreboard.getTeams()) {
+			if(t.getName().equalsIgnoreCase(name))
+				return true;
+		}
+		return false;
+	}
 	
 }

--- a/TemplarWar/src/me/Duppy/TemplarWar/Main/Main.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Main/Main.java
@@ -1,13 +1,6 @@
 package me.Duppy.TemplarWar.Main;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.util.Date;
 import java.util.Map.Entry;
-import java.util.Timer;
-import java.util.TimerTask;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -64,15 +57,14 @@ public class Main extends JavaPlugin{
 		BukkitTask inviteTask = new InviteCleaner(Plugin.plugin.getConfig().getInt("defaults.invitetime")+1).runTaskTimer(Plugin.plugin, 0, 20);
 		
 		//Upkeep code
-		Timer timer = new Timer();
-        LocalDateTime tomorrowMidnight = LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT).plusDays(1);
-        Date date = Date.from(tomorrowMidnight.atZone(ZoneId.systemDefault()).toInstant());
-        timer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                GuildManager.applyUpkeep();
-            }
-        }, date);
+		Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new Runnable(){
+
+			@Override
+			public void run() {
+				GuildManager.applyUpkeep();
+			}
+			//Code
+			}, 1, 20); //1 tick before first execution
 	}
 	
 	public void onDisable() {

--- a/TemplarWar/src/me/Duppy/TemplarWar/Teams/Team.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Teams/Team.java
@@ -3,24 +3,35 @@ package me.Duppy.TemplarWar.Teams;
 import java.util.ArrayList;
 import java.util.UUID;
 
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 import me.Duppy.TemplarWar.Guilds.Guilds.Guild;
+import me.Duppy.TemplarWar.Guilds.Guilds.GuildManager;
+import me.Duppy.TemplarWar.Main.ConfigManager;
 
 public class Team {
 	private int points;
 	private ArrayList<UUID> players;
 	private String name,color;
 	private ArrayList<Guild> guilds;
-	//Empty Constructor
-	public Team() {
+	private org.bukkit.scoreboard.Team scoreBoardTeam;
+	
+	//Constructor used during setup
+	public Team(String name) {
 		players = new ArrayList<UUID>();
+		this.scoreBoardTeam = GuildManager.mainScoreboard.registerNewTeam(name);
+		this.name = name;
 	}
 	
+	//Constructor used by players
 	public Team(String name,UUID creator) {
+		this.scoreBoardTeam = GuildManager.mainScoreboard.registerNewTeam(name);
+		setColor("red");
+		updateColor();
 		this.players = new ArrayList<UUID>();
 		this.players.add(creator);
-		setColor("red");
+		this.scoreBoardTeam.addEntry(ConfigManager.getPlayername(creator));
 		this.name = name;
 		this.guilds = new ArrayList<Guild>();
 	}
@@ -81,6 +92,11 @@ public class Team {
 				this.color = "red";
 				break;
 		}
+		updateColor();
+	}
+	
+	public org.bukkit.scoreboard.Team getScoreBoardTeam() {
+		return this.scoreBoardTeam;
 	}
 	//End Getter and Setters
 	
@@ -89,12 +105,14 @@ public class Team {
 	public void addPlayer(Player p) {
 		if(!this.players.contains(p.getUniqueId())) {
 			this.players.add(p.getUniqueId());
+			this.scoreBoardTeam.addEntry(p.getName());
 		}
 	}
 	
 	public void removePlayer(Player p){
 		if(this.players.contains(p.getUniqueId())) {
 			this.players.remove(p.getUniqueId());
+			this.scoreBoardTeam.removeEntry(p.getName());
 		}
 	}
 	
@@ -119,6 +137,31 @@ public class Team {
 		if(guilds.contains(g))
 			guilds.remove(g);
 	}
+	
+	public void updateColor() {
+		switch(this.color) {
+		case "green":
+			this.scoreBoardTeam.setColor(ChatColor.GREEN);
+			break;
+			
+		case "blue":
+			this.scoreBoardTeam.setColor(ChatColor.BLUE);
+			break;
+		
+		case "red":
+			this.scoreBoardTeam.setColor(ChatColor.RED);
+			break;
+		case "yellow":
+			this.scoreBoardTeam.setColor(ChatColor.YELLOW);
+			break;
+			
+		//This should never call. Team color should also be set or default by red.
+		default:
+			this.scoreBoardTeam.setColor(ChatColor.RED);
+			break;
+		}
+	}
+	
 
 	//End methods
 

--- a/TemplarWar/src/me/Duppy/TemplarWar/Teams/TeamManager.java
+++ b/TemplarWar/src/me/Duppy/TemplarWar/Teams/TeamManager.java
@@ -1,8 +1,10 @@
 package me.Duppy.TemplarWar.Teams;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.Map.Entry;
 
 import me.Duppy.TemplarWar.Guilds.Guilds.Guild;
 import me.Duppy.TemplarWar.Guilds.Guilds.GuildManager;
@@ -25,8 +27,7 @@ public class TeamManager {
 	public static void setupTeams() {
 		teams = new ArrayList<Team>();
 		for(String team : cfgm.getTeams().getKeys(false)) {
-			Team t = new Team();
-			t.setName(team);
+			Team t = new Team(team);
 			t.setPoints(cfgm.getTeams().getInt(team + ".points"));
 			//Get String list and convert it into a UUID list
 			ArrayList<UUID> players = new ArrayList<UUID>();
@@ -63,11 +64,29 @@ public class TeamManager {
 	}
 	
 	public static void removeTeam(Team team) {
+		//Safe removal of guilds if they are apart of inputted team
+		Iterator<Guild> itr = GuildManager.getGuildList().iterator();
+	    while (itr.hasNext()) {
+	        Guild g = itr.next();
+	        if(g.getTeam().getName().equalsIgnoreCase(team.getName())) {
+		        GuildManager.mainScoreboard.getTeam(g.getName()).unregister();
+				//Add player back to general team scoreboard
+				String playername = "";
+				for(Entry<UUID, String> u : g.getGuildMap().entrySet()) {
+					playername = ConfigManager.getPlayername(u.getKey());
+					g.getTeam().getScoreBoardTeam().addEntry(playername);
+				}
+		        itr.remove();
+		        if(g.getTeam().getGuilds().contains(g)) {
+					g.getTeam().removeGuild(g);
+				}
+	        }
+	      
+	    }
+	    //Remove the team
 		if(teams.contains(team)) {
+			team.getScoreBoardTeam().unregister();
 			teams.remove(team);
-		}
-		for(Guild g : team.getGuilds()) {
-			GuildManager.removeGuild(g);
 		}
 	}
 	


### PR DESCRIPTION
Upkeep now calculates every second
Fixed bug where deleting guild via upkeep did not unregister team
Fixed bug where players can create teams with the same name
Fixed bug where deleting a team threw a null error
Teammates can no longer damage each other via potions/arrows/hand items
Player displaynames are now colored by their team's color
Bolded guild names for readability
Minor config changes
Minor bug fixes